### PR TITLE
Fix param name parsing in case of Object property names

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -59,7 +59,7 @@
                 if ( keys_last ) {
                     // Complex key, build deep object structure based on a few rules:
                     // * The 'cur' pointer starts at the object top-level.
-                    // * [] = array push (n is set to array length), [n] = array if n is 
+                    // * [] = array push (n is set to array length), [n] = array if n is
                     //   numeric, otherwise object.
                     // * If at the last keys part, set the value.
                     // * For each keys part, if the current level is undefined create an
@@ -81,7 +81,7 @@
                         // val is already an array, so push on the next value.
                         obj[key].push( val );
 
-                    } else if ( obj[key] !== undefined ) {
+                    } else if ( {}.hasOwnProperty.call(obj, key) ) {
                         // val isn't an array, but since a second value has been specified,
                         // convert val into an array.
                         obj[key] = [ obj[key], val ];

--- a/test/jquery-deparam.specs.js
+++ b/test/jquery-deparam.specs.js
@@ -33,6 +33,10 @@ describe('jquery-deparam', function(){
     it('serializes numbers into strings when without coercion', function(){
         deparam('prop=1234').prop.should.be.a('string');
     });
+    it('parses any param name correctly including those of built in Object property names', function(){
+        deparam('hasOwnProperty=sillystring').hasOwnProperty.should.equal('sillystring');
+        deparam('prop[hasOwnProperty]=sillystring').prop.hasOwnProperty.should.equal('sillystring');
+    });
     describe('bbq specs', function(){
         it('deserializes 1.4-style params', function(){
             var paramStr = 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=1';


### PR DESCRIPTION
As objects in javascript are not pure maps we cannot relay on `object[key]` in case if key equals some built in property name. Instead when treating objects as maps we should use `{}.hasOwnProperty.call(object, key)`. Test case included.