### PR TITLE
Removing jQuery dependency in favour of an opt-in pattern

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -1,10 +1,9 @@
 (function(deparam){
     if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-        var jquery = require('jquery');
-        module.exports = deparam(jquery);
+        module.exports = deparam();
     } else if (typeof define === 'function' && define.amd){
-        define(['jquery'], function(jquery){
-            return deparam(jquery);
+        define({
+            deparam: deparam()
         });
     } else {
         var global
@@ -13,9 +12,9 @@
         } catch (e) {
           global = window; // fails only if browser (https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives)
         }
-        global.deparam = deparam(jQuery); // assume jQuery is in global namespace
+        global.deparam = deparam();
     }
-})(function ($) {
+})(function () {
     var deparam = function( params, coerce ) {
         var obj = {},
         coerce_types = { 'true': !0, 'false': !1, 'null': null };
@@ -107,7 +106,6 @@
 
         return obj;
     };
-    $.prototype.deparam = $.deparam = deparam;
     deparam.addTojQuery = function() {
         if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
             var jquery = require('jquery');

--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -108,5 +108,19 @@
         return obj;
     };
     $.prototype.deparam = $.deparam = deparam;
+    deparam.addTojQuery = function() {
+        if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+            var jquery = require('jquery');
+            jquery.prototype.deparam = jquery.deparam = deparam;
+        } else if (typeof define === 'function' && define.amd){
+            define(['jquery'], function(jquery){
+                jquery.prototype.deparam = jquery.deparam = deparam;
+            });
+        } else if (jQuery) {
+            // assume jQuery may be in global namespace
+            jQuery.prototype.deparam = jQuery.deparam = deparam;
+        }
+        return deparam;
+    }
     return deparam;
 });

--- a/test/jquery-deparam.specs.js
+++ b/test/jquery-deparam.specs.js
@@ -1,13 +1,9 @@
 var should = require('chai').should();
-var jquery = require('jquery');
 var deparam = require('../jquery-deparam');
 
 describe('jquery-deparam', function(){
     it('loads through CommonJS', function(){
         require('../jquery-deparam').should.be.a('function');
-    });
-    it('is available through the jquery namespace', function(){
-      jquery.deparam.should.be.a('function');
     });
     it('serializes strings', function(){
         deparam('prop=sillystring').prop.should.be.a('string');
@@ -36,6 +32,11 @@ describe('jquery-deparam', function(){
     it('parses any param name correctly including those of built in Object property names', function(){
         deparam('hasOwnProperty=sillystring').hasOwnProperty.should.equal('sillystring');
         deparam('prop[hasOwnProperty]=sillystring').prop.hasOwnProperty.should.equal('sillystring');
+    });
+    it('is available through the jquery namespace', function(){
+      deparam.addTojQuery();
+      var jquery = require('jquery');
+      jquery.deparam.should.be.a('function');
     });
     describe('bbq specs', function(){
         it('deserializes 1.4-style params', function(){


### PR DESCRIPTION
Since the current jQuery dependency is simply to append the deparam function to the jQuery namespace, this PR allows you to opt-in if that is desired. However, if you want to eliminate the jQuery dependency in your project you can elect not to opt-in and still gain all the functionality of this library. For context, this might be useful when combining this library with [jquery-param](https://github.com/knowledgecode/jquery-param).

This PR allows you to choose whether or not to opt-in:
```js
// opt-in and register deparam into jQuery namespace
var deparam = require('jquery-deparam').addTojQuery();
// deparam === require('jquery').deparam

// don't depend on jQuery
var deparam = require('jquery-deparam');
```

I kind of just picked a semantic name for the opt-in function, I'm certainly open to a name change.

this resolves #17 