### PR TITLE
Making jQuery dependency optional

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -1,19 +1,22 @@
 (function(deparam){
     if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-        var jquery = require('jquery');
+        try {
+            var jquery = require('jquery');
+        } catch (e) {
+        }
         module.exports = deparam(jquery);
     } else if (typeof define === 'function' && define.amd){
         define(['jquery'], function(jquery){
             return deparam(jquery);
         });
     } else {
-        var global
+        var global;
         try {
           global = (false || eval)('this'); // best cross-browser way to determine global for < ES5
         } catch (e) {
           global = window; // fails only if browser (https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives)
         }
-        global.deparam = deparam(jQuery); // assume jQuery is in global namespace
+        global.deparam = deparam(global.jQuery); // assume jQuery is in global namespace
     }
 })(function ($) {
     var deparam = function( params, coerce ) {
@@ -107,6 +110,8 @@
 
         return obj;
     };
-    $.prototype.deparam = $.deparam = deparam;
+    if ($) {
+      $.prototype.deparam = $.deparam = deparam;
+    }
     return deparam;
 });


### PR DESCRIPTION
a new strategy (instead of #18) to resolve #17.

Assume jQuery exists and try to load it, if loading it is not possible then continue but exclude any jQuery registration. I tested this out with the existing tests and they run fine when jQuery is not available (except the one test that specifically checks for jQuery registration).

The only caveat here is that AMD doesn't support defining a module with a jQuery dependency and dealing with that dependency missing (this is a limitation of AMD). The best alternative I could think of was to try and register the module into jQuery after it is defined by using a `require` statement, but this is not very elegant (really, AMD is just not designed to support this). The code would look something like this:

```
        define(function(){
            var result = deparam(null);
            require(['jquery'], function(jquery) {
                $.prototype.deparam = $.deparam = result;
            }, function(e) {
                // jquery is missing
            });
            return result;
        });
```

This is a pretty hack-y way to do it but it does essentially accomplish the desired result. I didn't bother including this code in the PR because I'm not sure if you really want it. Easy to add another commit if you think it has value.