### PR TITLE
add some error-checking and edge-case handling

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -23,6 +23,14 @@
         var obj = {},
         coerce_types = { 'true': !0, 'false': !1, 'null': null };
 
+        // If params is an empty string or otherwise falsy, return obj.
+        if (!params) {
+            return obj;
+        // Make sure the string does not start with a '?' character.
+        } else if (params.charAt(0) === '?') {
+            params = params.substr(1);
+        }
+
         // Iterate over all name=value pairs.
         params.replace(/\+/g, ' ').split('&').forEach(function(v){
             var param = v.split( '=' ),

--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -26,9 +26,6 @@
         // If params is an empty string or otherwise falsy, return obj.
         if (!params) {
             return obj;
-        // Make sure the string does not start with a '?' character.
-        } else if (params.charAt(0) === '?') {
-            params = params.substr(1);
         }
 
         // Iterate over all name=value pairs.


### PR DESCRIPTION
`jquery.deparam(null)` throws an error, which (while null is not something that can be returned by `jquery.param()`) should be handled cleanly. Additionally, if a user is careless about how they parse their URL, they may pass in a string with the `?` prepended; deparam can and should silently handle that. This solves #21.