### PR TITLE
jquery-deparam: coerce standalone keys to null values

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -19,7 +19,7 @@
         global.deparam = deparam(global.jQuery); // assume jQuery is in global namespace
     }
 })(function ($) {
-    var deparam = function( params, coerce ) {
+    var deparam = function( params, coerce, standaloneKeys ) {
         var obj = {},
         coerce_types = { 'true': !0, 'false': !1, 'null': null };
 
@@ -68,48 +68,59 @@
                     : coerce_types[val] !== undefined           ? coerce_types[val] // true, false, null
                     : val;                                                          // string
                 }
+            }
 
-                if ( keys_last ) {
-                    // Complex key, build deep object structure based on a few rules:
-                    // * The 'cur' pointer starts at the object top-level.
-                    // * [] = array push (n is set to array length), [n] = array if n is
-                    //   numeric, otherwise object.
-                    // * If at the last keys part, set the value.
-                    // * For each keys part, if the current level is undefined create an
-                    //   object or array based on the type of the next keys part.
-                    // * Move the 'cur' pointer to the next level.
-                    // * Rinse & repeat.
-                    for ( ; i <= keys_last; i++ ) {
-                        key = keys[i] === '' ? cur.length : keys[i];
-                        cur = cur[key] = i < keys_last
-                        ? cur[key] || ( keys[i+1] && isNaN( keys[i+1] ) ? {} : [] )
-                        : val;
-                    }
+            else if ( param.length === 1 && key ) {
+                // No value was defined, so set something meaningful.
+                val = coerce
+                  ? standaloneKeys
+                    ? null
+                    : undefined
+                  : '';
 
-                } else {
-                    // Simple key, even simpler rules, since only scalars and shallow
-                    // arrays are allowed.
+                if (!standaloneKeys) {
+                    // Backwards-compatibility:
+                    // * Prior to the introduction of the standaloneKeys parameter, keys
+                    //   without corresponding values would result in an undefined entry
+                    keys_last = false;
+                    obj[key] = undefined;
+                }
+            }
 
-                    if ( Object.prototype.toString.call( obj[key] ) === '[object Array]' ) {
-                        // val is already an array, so push on the next value.
-                        obj[key].push( val );
-
-                    } else if ( {}.hasOwnProperty.call(obj, key) ) {
-                        // val isn't an array, but since a second value has been specified,
-                        // convert val into an array.
-                        obj[key] = obj[key] !== undefined ? [ obj[key], val ] : val;
-
-                    } else {
-                        // val is a scalar.
-                        obj[key] = val;
-                    }
+            if ( keys_last ) {
+                // Complex key, build deep object structure based on a few rules:
+                // * The 'cur' pointer starts at the object top-level.
+                // * [] = array push (n is set to array length), [n] = array if n is
+                //   numeric, otherwise object.
+                // * If at the last keys part, set the value.
+                // * For each keys part, if the current level is undefined create an
+                //   object or array based on the type of the next keys part.
+                // * Move the 'cur' pointer to the next level.
+                // * Rinse & repeat.
+                for ( ; i <= keys_last; i++ ) {
+                    key = keys[i] === '' ? cur.length : keys[i];
+                    cur = cur[key] = i < keys_last
+                    ? cur[key] || ( keys[i+1] && isNaN( keys[i+1] ) ? {} : [] )
+                    : val;
                 }
 
             } else if ( key ) {
-                // No value was defined, so set something meaningful.
-                obj[key] = coerce
-                ? undefined
-                : '';
+                // Simple key, even simpler rules, since only scalars and shallow
+                // arrays are allowed.
+
+                if ( Object.prototype.toString.call( obj[key] ) === '[object Array]' ) {
+                    // val is already an array, so push on the next value.
+                    obj[key].push( val );
+
+                } else if ( {}.hasOwnProperty.call(obj, key) ) {
+                    // val isn't an array, but since a second value has been specified,
+                    // convert val into an array.
+                    obj[key] = obj[key] === undefined ? val : [ obj[key], val ];
+
+                } else {
+                    // val is a scalar.
+                    obj[key] = val;
+                }
             }
         });
 

--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -97,7 +97,7 @@
                     } else if ( {}.hasOwnProperty.call(obj, key) ) {
                         // val isn't an array, but since a second value has been specified,
                         // convert val into an array.
-                        obj[key] = [ obj[key], val ];
+                        obj[key] = obj[key] !== undefined ? [ obj[key], val ] : val;
 
                     } else {
                         // val is a scalar.

--- a/test/jquery-deparam.specs.js
+++ b/test/jquery-deparam.specs.js
@@ -53,5 +53,15 @@ describe('jquery-deparam', function(){
             var paramsObj = { a:[1,2,3], b:4, c:[5,6,true,false,undefined,''], d:7 };
             deparam(paramStr, true).should.deep.equal(paramsObj);
         });
+        it('deserializes compatibly with bbq-sans-standaloneKeys', function(){
+            var paramStr = 'a=1&a&b=2&c=3&c=undefined&c=&d&e[a]=4&e[b]&e[c]=';
+            var paramsObj = { a:'', b:'2', c:['3','undefined',''], d:'', e:{a:'4',c:''}, 'e[b]':'' };
+            deparam(paramStr).should.deep.equal(paramsObj);
+        });
+        it('deserializes compatibly with coercion with bbq-sans-standaloneKeys', function(){
+            var paramStr = 'a=1&a&b=2&c=3&c=undefined&c=&d&e[a]=4&e[b]&e[c]=';
+            var paramsObj = { a:undefined, b:2, c:[3,undefined,''], d:undefined, e:{a:4,c:''}, 'e[b]':undefined };
+            deparam(paramStr, true).should.deep.equal(paramsObj);
+        });
     });
 });

--- a/test/jquery-deparam.specs.js
+++ b/test/jquery-deparam.specs.js
@@ -37,6 +37,18 @@ describe('jquery-deparam', function(){
         deparam('hasOwnProperty=sillystring').hasOwnProperty.should.equal('sillystring');
         deparam('prop[hasOwnProperty]=sillystring').prop.hasOwnProperty.should.equal('sillystring');
     });
+    it('parses empty keys as strings when using standalone keys without coercion', function(){
+        deparam('prop', false, true).prop.should.be.a('string');
+    });
+    it('parses empty-strings when using standalone keys without coercion', function(){
+        deparam('prop=', false, true).prop.should.be.a('string');
+    });
+    it('parses empty keys into null values when using standalone keys and coerced', function(){
+        should.equal(deparam('prop', true, true).prop, null);
+    });
+    it('parses empty-strings when using standalone keys and coerced', function(){
+        deparam('prop=', true, true).prop.should.be.a('string');
+    });
     describe('bbq specs', function(){
         it('deserializes 1.4-style params', function(){
             var paramStr = 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=1';


### PR DESCRIPTION
This pull request adds support for a `standaloneKeys` parameter in the `jquery-deparam` library, allowing clients to decode standalone query-string keys (e.g. the key `b` in the string `?a=1&b&c=3`) as `null`.

Standalone keys are deserialized to nulls only when the `coerce` parameter is also enabled. Backwards-compatibility is maintained with prior versions of `jquery-bbq` and `jquery-deparam`, and test coverage to illustrate this is provided.

This pull request is a parallel application of the changes proposed in https://github.com/cowboy/jquery-bbq/pull/60.

This proposed change corresponds to jquery/jquery#4708 in which the ability to serialize JavaScript objects containing `null` values to query strings is proposed.