### PR TITLE
Support when value includes '=' character

### DIFF
--- a/jquery-deparam.js
+++ b/jquery-deparam.js
@@ -58,8 +58,9 @@
             }
 
             // Are we dealing with a name=value pair, or just a name?
-            if ( param.length === 2 ) {
-                val = decodeURIComponent( param[1] );
+            if ( param.length < 2 ) {
+                value = param.slice(1).join('='); // Suport when value has '=' character.
+                val = decodeURIComponent( value );
 
                 // Coerce values.
                 if ( coerce ) {

--- a/test/jquery-deparam.specs.js
+++ b/test/jquery-deparam.specs.js
@@ -37,6 +37,9 @@ describe('jquery-deparam', function(){
         deparam('hasOwnProperty=sillystring').hasOwnProperty.should.equal('sillystring');
         deparam('prop[hasOwnProperty]=sillystring').prop.hasOwnProperty.should.equal('sillystring');
     });
+    it('parses base64 encoded value correctly', function(){
+        deparam('encodedProp=c2loeWVvbg==').hasOwnProperty.should.equal('c2loeWVvbg==');
+    });
     describe('bbq specs', function(){
         it('deserializes 1.4-style params', function(){
             var paramStr = 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=1';


### PR DESCRIPTION
Since param is splitted by '=' at first, deparam couldn't support base64
encoded value which could have '=' character in it.
To solve this problem, when we deal with 'name=value' type, join param with '=' again except the first one, which is a key, and treat them as a value.

Signed-off-by: Sihyeon Jang <uneedsihyeon@gmail.com>